### PR TITLE
Normalise functions using an NbE approach with HOAS

### DIFF
--- a/parsley-garnish/input/src/main/scala/test/FunctionTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/FunctionTest.scala
@@ -44,15 +44,15 @@ object FunctionTest {
   // val mapValFunc = pure("parsley").map(valFunc.curried)
 
   // TODO: named functions - this is just a Term.Name("func_name"), with symbols
-  // val mapValFunc = pure("parsley").map(valFuncCurried)
-  // val mapDefFunc = pure("parsley").map(defFuncCurried)
-  // val mapDefFuncGeneric = pure("parsley").map(defFuncGenericCurried)
+  val mapValFunc = pure("parsley").map(valFuncCurried)
+  val mapDefFunc = pure("parsley").map(defFuncCurried)
+  val mapDefFuncGeneric = pure("parsley").map(defFuncGenericCurried)
 
   /* 
   LIKELY WONT DO: it seems impossible to find the type of placeholder variables
   TODO: But we can at least get the shape of the function
   */
-  // val mapPlaceholder = pure("parsley").map(_ + "garnish")
+  val mapPlaceholder = pure("parsley").map(_ + "garnish")
 
   /*
   TODO: is this any different from how it would work for x => One(x.length)? Don't think so
@@ -61,13 +61,13 @@ object FunctionTest {
   Also possible to get signature from symbol of method body, if the types are concrete
     (if it's in a lambda like this, it should always be?)
   */
-  // val mapLambda = pure("parsley").map(x => x.toInt + 12)
+  val mapLambda = pure("parsley").map(x => x.toInt + 12)
 
   // TODO: standard anonymous functions (i.e. lambdas) - Term.Function(ParamClause(params), body)
   // get argument types from ParamClause
   // recursively descend into body, in case the function is curried
   // get return type from final body
-  // val mapApplyMethodLambda = pure("parsley").map(x => One(x.length))
+  val mapApplyMethodLambda = pure("parsley").map(x => One(x.length))
 
   // I the below should end up parsed like \x -> \y -> OPAQUE(One(x.length + y))
   // it's NOT worth trying to turn the body of the lambda into our Function representation
@@ -75,10 +75,10 @@ object FunctionTest {
 
   // TODO: Need to have some sort of traversal through and convert this to a lambda
   // This is a Term.AnonymousFunction(...)
-  // val mapApplyMethodPlaceholder = pure("parsley").map(OneGeneric(_))
-  // val mapApplyMethodPlaceholderLabelledType = pure("parsley").map(OneGeneric(_: String))
+  val mapApplyMethodPlaceholder = pure("parsley").map(OneGeneric(_))
+  val mapApplyMethodPlaceholderLabelledType = pure("parsley").map(OneGeneric(_: String))
 
-  // val mapApplyMethod = pure(1).map(Two.curried.apply)
+  val mapApplyMethod = pure(1).map(Two.curried.apply)
 
   // val explicitLiftValFunc = lift2(valFunc, pure("parsley"), pure("garnish"))
   // val explicitLiftDefFunc = lift2(defFunc, pure("parsley"), pure("garnish"))

--- a/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
@@ -11,6 +11,7 @@ import parsley.syntax.character._
 object SimplifyComplexParsersTest {
     def add[A](a: A, b: String): String = a.toString + b
 
+    /*
     val altRightNeutral = "anise" <|> empty
     val altLeftNeutral = empty | "coriander"
 
@@ -23,8 +24,9 @@ object SimplifyComplexParsersTest {
     val fmapLeftAbsorb = empty.map(s => add(s, "sage"))
 
     val fmapHomomorphism = pure("parsley").map(s => add(s, "wasabi"))
+    */
 
     val fmapComposition = string("saffron").map(s => add(s, "tarragon")).map(s => add(s, "turmeric"))
 
-    def defParser(p: Parsley[String]): Parsley[String] = p.map(s => add(s, "oregano")).map(s => add(s, "paprika"))
+    // def defParser(p: Parsley[String]): Parsley[String] = p.map(s => add(s, "oregano")).map(s => add(s, "paprika"))
 }

--- a/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
@@ -11,7 +11,6 @@ import parsley.syntax.character._
 object SimplifyComplexParsersTest {
     def add[A](a: A, b: String): String = a.toString + b
 
-    /*
     val altRightNeutral = "anise" <|> empty
     val altLeftNeutral = empty | "coriander"
 
@@ -24,9 +23,8 @@ object SimplifyComplexParsersTest {
     val fmapLeftAbsorb = empty.map(s => add(s, "sage"))
 
     val fmapHomomorphism = pure("parsley").map(s => add(s, "wasabi"))
-    */
 
     val fmapComposition = string("saffron").map(s => add(s, "tarragon")).map(s => add(s, "turmeric"))
 
-    // def defParser(p: Parsley[String]): Parsley[String] = p.map(s => add(s, "oregano")).map(s => add(s, "paprika"))
+    def defParser(p: Parsley[String]): Parsley[String] = p.map(s => add(s, "oregano")).map(s => add(s, "paprika"))
 }

--- a/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
@@ -18,7 +18,7 @@ object SimplifyComplexParsersTest {
 
     val apRightAbsorb = empty <*> optional("fennel")
     val apHomomorphism = pure((x: Int) => x + 1) <*> pure(1)
-    val fmap = pure((s: String) => s + "thyme") <*> "rosemary"
+    val fmap = pure((s: String) => s + "thyme") <*> "rosemary" // TODO: this doesn't compile
 
     val fmapLeftAbsorb = empty.map(s => add(s, "sage"))
 

--- a/parsley-garnish/output/src/main/scala/test/FunctionTest.scala
+++ b/parsley-garnish/output/src/main/scala/test/FunctionTest.scala
@@ -41,15 +41,15 @@ object FunctionTest {
   // val mapValFunc = pure("parsley").map(valFunc.curried)
 
   // TODO: named functions - this is just a Term.Name("func_name"), with symbols
-  // val mapValFunc = pure("parsley").map(valFuncCurried)
-  // val mapDefFunc = pure("parsley").map(defFuncCurried)
-  // val mapDefFuncGeneric = pure("parsley").map(defFuncGenericCurried)
+  val mapValFunc = pure(valFuncCurried("parsley"))
+  val mapDefFunc = pure(defFuncCurried("parsley"))
+  val mapDefFuncGeneric = pure(defFuncGenericCurried("parsley"))
 
   /* 
   LIKELY WONT DO: it seems impossible to find the type of placeholder variables
   TODO: But we can at least get the shape of the function
   */
-  // val mapPlaceholder = pure("parsley").map(_ + "garnish")
+  val mapPlaceholder = pure("parsley" + "garnish")
 
   /*
   TODO: is this any different from how it would work for x => One(x.length)? Don't think so
@@ -58,13 +58,13 @@ object FunctionTest {
   Also possible to get signature from symbol of method body, if the types are concrete
     (if it's in a lambda like this, it should always be?)
   */
-  // val mapLambda = pure("parsley").map(x => x.toInt + 12)
+  val mapLambda = pure("parsley".toInt + 12)
 
   // TODO: standard anonymous functions (i.e. lambdas) - Term.Function(ParamClause(params), body)
   // get argument types from ParamClause
   // recursively descend into body, in case the function is curried
   // get return type from final body
-  // val mapApplyMethodLambda = pure("parsley").map(x => One(x.length))
+  val mapApplyMethodLambda = pure(One("parsley".length))
 
   // I the below should end up parsed like \x -> \y -> OPAQUE(One(x.length + y))
   // it's NOT worth trying to turn the body of the lambda into our Function representation
@@ -72,10 +72,10 @@ object FunctionTest {
 
   // TODO: Need to have some sort of traversal through and convert this to a lambda
   // This is a Term.AnonymousFunction(...)
-  // val mapApplyMethodPlaceholder = pure("parsley").map(OneGeneric(_))
-  // val mapApplyMethodPlaceholderLabelledType = pure("parsley").map(OneGeneric(_: String))
+  val mapApplyMethodPlaceholder = pure(OneGeneric("parsley"))
+  val mapApplyMethodPlaceholderLabelledType = pure(OneGeneric("parsley": String))
 
-  // val mapApplyMethod = pure(1).map(Two.curried.apply)
+  val mapApplyMethod = pure(Two.curried.apply(1))
 
   // val explicitLiftValFunc = lift2(valFunc, pure("parsley"), pure("garnish"))
   // val explicitLiftDefFunc = lift2(defFunc, pure("parsley"), pure("garnish"))

--- a/parsley-garnish/output/src/main/scala/test/FunctionTest.scala
+++ b/parsley-garnish/output/src/main/scala/test/FunctionTest.scala
@@ -1,0 +1,127 @@
+package test
+
+import parsley.Parsley._
+import parsley.character._
+import parsley.lift._
+import parsley.syntax.lift._
+import parsley.syntax.zipped._
+import parsley.generic._
+
+// * map, lift (implicit and explicit), zipped, (.as perhaps?)
+//   * named function literals (val)
+//   * named method literals (def)
+//   * anonymous functions i.e. lambdas
+//   * functions with placeholder syntax
+//   * apply methods of case classes - symbol will tell its a class signature so we use this as a clue to look at synthetics???
+// * generic bridges -- I reckon the information will probably show up in synthetics again
+// so overall, we have shapes (x, y).xxx(f) ; xxx(f, x, y) ; f.xxx(x, y) ; f(x, y)
+//  hopefully this won't matter though, as I want to only need to use term `f`, without needing surrounding contextual information
+
+object FunctionTest {
+  case class One(x: Int)
+  case class Two(x: Int, y: Int)
+
+  case class OneGeneric[A](a: A)
+  case class TwoGeneric[A, B](a: A, b: B)
+
+  case class OneBridged(x: Int)
+  object OneBridged extends ParserBridge1[Int, OneBridged]
+  case class TwoBridged(x: Int, y: Int)
+  object TwoBridged extends ParserBridge2[Int, Int, TwoBridged]
+
+  val valFunc = (x: String, y: String) => x + y
+  val valFuncCurried = (x: String) => (y: String) => x + y
+
+  def defFunc(x: String, y: String) = x + y
+  def defFuncCurried = defFunc.curried
+  def defFuncGeneric[A, B](x: A, y: B) = (x, y)
+  def defFuncGenericCurried[A, B](x: A)(y: B) = (x, y)
+
+  /* WONT DO: can't extract concrete type of function from signature, and there are no synthetics */
+  // val mapValFunc = pure("parsley").map(valFunc.curried)
+
+  // TODO: named functions - this is just a Term.Name("func_name"), with symbols
+  // val mapValFunc = pure("parsley").map(valFuncCurried)
+  // val mapDefFunc = pure("parsley").map(defFuncCurried)
+  // val mapDefFuncGeneric = pure("parsley").map(defFuncGenericCurried)
+
+  /* 
+  LIKELY WONT DO: it seems impossible to find the type of placeholder variables
+  TODO: But we can at least get the shape of the function
+  */
+  // val mapPlaceholder = pure("parsley").map(_ + "garnish")
+
+  /*
+  TODO: is this any different from how it would work for x => One(x.length)? Don't think so
+  We can find the type of each argument via its signature
+  And the return type possibly via synthetics on the .map term?
+  Also possible to get signature from symbol of method body, if the types are concrete
+    (if it's in a lambda like this, it should always be?)
+  */
+  // val mapLambda = pure("parsley").map(x => x.toInt + 12)
+
+  // TODO: standard anonymous functions (i.e. lambdas) - Term.Function(ParamClause(params), body)
+  // get argument types from ParamClause
+  // recursively descend into body, in case the function is curried
+  // get return type from final body
+  // val mapApplyMethodLambda = pure("parsley").map(x => One(x.length))
+
+  // I the below should end up parsed like \x -> \y -> OPAQUE(One(x.length + y))
+  // it's NOT worth trying to turn the body of the lambda into our Function representation
+  val mapApplyMethodLambdaCurried = pure("parsley").map(x => (y: Int) => One(x.length + y))
+
+  // TODO: Need to have some sort of traversal through and convert this to a lambda
+  // This is a Term.AnonymousFunction(...)
+  // val mapApplyMethodPlaceholder = pure("parsley").map(OneGeneric(_))
+  // val mapApplyMethodPlaceholderLabelledType = pure("parsley").map(OneGeneric(_: String))
+
+  // val mapApplyMethod = pure(1).map(Two.curried.apply)
+
+  // val explicitLiftValFunc = lift2(valFunc, pure("parsley"), pure("garnish"))
+  // val explicitLiftDefFunc = lift2(defFunc, pure("parsley"), pure("garnish"))
+  // val explicitLiftDefFuncGeneric = lift2(defFuncGeneric[String, String], pure("parsley"), pure("garnish"))
+  // val explicitLiftPlaceholder = lift2((_: String) + (_: String), pure("parsley"), pure("garnish"))
+  val explicitLiftLambda = lift2((a: String, b: String) => a + b, pure("parsley"), pure("garnish"))
+  // val explicitLiftApplyMethodLambda = lift2((a: String, b: String) => TwoGeneric(a, b), pure("parsley"), pure("garnish"))
+  // val explicitLiftApplyMethodPlaceholder = lift2(Two(_, _), pure(1), pure(2))
+  // val explicitLiftApplyMethod = lift2(Two, pure(1), pure(2))
+
+  // val implicitLiftValFunc = valFunc.lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftDefFunc = defFunc.lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftDefFuncGeneric = defFuncGeneric[String, String].lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftPlaceholder = ((_: String) + (_: String)).lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftLambda = ((a: String, b: String) => a + b).lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftApplyMethodLambda = ((a: String, b: String) => TwoGeneric(a, b)).lift(pure("parsley"), pure("garnish"))
+  // val implicitLiftApplyMethod = TwoGeneric[Int, Int].lift(pure(1), pure(2))
+
+  // val zippedValFunc = (pure("parsley"), pure("garnish")).zipped(valFunc)
+  // val zippedDefFunc = (pure("parsley"), pure("garnish")).zipped(defFunc)
+  // val zippedDefFuncGeneric = (pure("parsley"), pure("garnish")).zipped(defFuncGeneric)
+  // val zippedPlaceholder = (pure("parsley"), pure("garnish")).zipped(_ + _)
+  // val zippedLambda = (pure("parsley"), pure("garnish")).zipped((a, b) => a + b)
+  // val zippedApplyMethodLambda = (pure("parsley"), pure("garnish")).zipped((a, b) => TwoGeneric(a, b))
+  // val zippedApplyMethod = (pure(1), pure(2)).zipped(Two)
+  // val zippedApplyMethodExplicit = (pure(1), pure(2)).zipped(Two.apply)
+  // val zippedApplyMethodPlaceholder = (pure(1), pure(2)).zipped(Two(_, _))
+
+  // val bridge1 = OneBridged(pure(1))
+  // val bridge2 = TwoBridged(pure(1), pure(2))
+
+  /*
+  val bridgeFrom = OneBridged.from(pure(1))
+  val bridgeFromInfix = OneBridged from pure(1)
+  */
+
+
+  /*
+  val complexLambda = item.map(x => {
+    if (x.isDigit) One(x.asDigit)
+    else OneGeneric(x)
+  })
+
+  val nameShadowingComplexLambda = item.map(x => {
+    if (x.isDigit) x => One(x) // in the returned function, x does not refer to the outer lambda's x
+    else (y: Int) => OneGeneric(y)
+  })
+  */
+}

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/analysis/ParserTransformer.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/analysis/ParserTransformer.scala
@@ -46,7 +46,6 @@ object ParserTransformer {
                                    (implicit doc: SemanticDocument): ParserDefinition = {
     val tpe = getParsleyType(sym)
     assert(tpe.isDefined, s"expected a Parsley type for $name, got ${sym.info.get.signature}")
-    println(s"%%% Building parser definition for $name with type $tpe")
     ParserDefinition(name, body.toParser, tpe.get, body)
   }
 }

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/analysis/ParserTransformer.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/analysis/ParserTransformer.scala
@@ -46,6 +46,7 @@ object ParserTransformer {
                                    (implicit doc: SemanticDocument): ParserDefinition = {
     val tpe = getParsleyType(sym)
     assert(tpe.isDefined, s"expected a Parsley type for $name, got ${sym.info.get.signature}")
+    println(s"%%% Building parser definition for $name with type $tpe")
     ParserDefinition(name, body.toParser, tpe.get, body)
   }
 }

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/implicits.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/implicits.scala
@@ -15,7 +15,7 @@ object implicits {
   }
 
   implicit class TermOps(private val term: Term) extends AnyVal {
-    import parsley.garnish.model.Parser, Parser._
+    import model.Parser, Parser._
 
     def toParser(implicit doc: SemanticDocument): Parser = {
       val transforms: PartialFunction[Term, Parser] = Seq(

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Function.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Function.scala
@@ -49,6 +49,19 @@ sealed abstract class Function extends Product with Serializable {
     case _ => true
   }
 
+  def reflect: HOAS = {
+    def reflect0(func: Function, env: Map[Var, HOAS]): HOAS = func match {
+      case v: Var => env.getOrElse(v, HOAS.Var(v.name))
+      // TODO: each HOAS binder needs to be named so I can substitute them back in for the Opaque case :(
+      case Lam(xs, f) => HOAS.Abs(vs => {
+        reflect0(f, env ++ xs.zip(vs))
+      })
+
+    }
+
+    reflect0(this, Map.empty)
+  }
+
   override def toString: String = term.syntax
   // override def toString: String = this match {
   //   case Opaque(t, _) => s"${Console.RED}${t.syntax}${Console.RESET}"

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Function.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Function.scala
@@ -22,7 +22,7 @@ sealed abstract class Function extends Product with Serializable {
   def normalise: Function = {
     println(s"1) NORMALISING $this")
     val reflected = this.reflect
-    println(s"2) REFLECTED TO ${reflected.reify}")
+    println(s"2) REFLECTED TO ${reflected}")
     val normalised = reflected.normalise
     println(s"3) NORMALISED TO $normalised")
     val reified = normalised.reify
@@ -63,7 +63,7 @@ sealed abstract class Function extends Product with Serializable {
   def reflect: HOAS = {
     def reflect0(func: Function, boundVars: Map[Var, HOAS]): HOAS = func match {
       case v @ Var(name, displayType) => boundVars.getOrElse(v, HOAS.Var(name, displayType))
-      case Lam(xs, f) => HOAS.Abs(vs => {
+      case Lam(xs, f) => HOAS.Abs(xs.size, vs => {
         // TODO: ACTUALLY IT MIGHT BE BECAUSE VARS ARE NOT BEING HASHED CORRECTLY
         // println(s"REFLECTING LAM with new ${xs.zip(vs)} = boundvars ${boundVars ++ xs.zip(vs)}")
         reflect0(f, boundVars ++ xs.zip(vs))

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
@@ -14,10 +14,8 @@ sealed abstract class HOAS extends Product with Serializable {
       case App(f, x) => f.whnf match {
         case Abs(_, g) => g(x).normalise
         case g      => App(g.normalise, x.map(_.normalise))
-        // case g      => App(g.normalise, x.normalise.asInstanceOf[Tuple]) // TODO: ew, but this should be guaranteed
       }
-      // case Tuple(xs) => Tuple(xs.map(_.normalise))
-      case Opaque(t, env) => Opaque(t, env.map { case (k, v) => k -> v.normalise })
+      case Translucent(t, env) => Translucent(t, env.map { case (k, v) => k -> v.normalise })
       case _ => this
     }
     // println(s"\tNORMALISED ${this.reify} to ${normalised.reify}")
@@ -29,22 +27,22 @@ sealed abstract class HOAS extends Product with Serializable {
       case Abs(_, g) => g(x).whnf
       case g      => App(g, x)
     }
-    case Opaque(t, env) => Opaque(t, env.map { case (k, v) => k -> v.whnf })
+    case Translucent(t, env) => Translucent(t, env.map { case (k, v) => k -> v.whnf })
     case _ => this
   }
 
   def reify: Function = {
     val reified = this match {
       case Abs(n, f) => {
-        println(s"REIFYING ABS $n $f")
-        val params = (1 to n).map(_ => Function.Var(Some("hoas"))).toList
+        // println(s"REIFYING ABS $n $f")
+        val params = (1 to n).map(_ => Function.Var.fresh(Some("hoas"))).toList
         Function.Lam(params, f(params.map(x => HOAS.Var(x.name, None))).reify)
       }
       case App(f, xs) => {
         // println(s"REIFYING APP $f $xs")
         Function.App(f.reify, xs.map(_.reify): _*)
       }
-      case Opaque(t, env) => Function.Opaque(t, env.map { case (v, f) => v -> f.reify })
+      case Translucent(t, env) => Function.Translucent(t, env.map { case (v, f) => v -> f.reify })
       case Var(name, displayType) => Function.Var(name, displayType)
     }
     // println(s"REIFIED $this to $reified")
@@ -71,7 +69,7 @@ object HOAS {
 
   // case class Tuple(xs: Seq[HOAS]) extends HOAS
 
-  case class Opaque(t: Term, env: Map[VarName, HOAS] = Map.empty) extends HOAS
+  case class Translucent(t: Term, env: Map[VarName, HOAS] = Map.empty) extends HOAS
 
   // def appC(f: HOAS, xs: HOAS*): HOAS = xs.foldLeft(f)(App(_, _))
   def appC(f: HOAS, xs: HOAS*): HOAS = xs.foldLeft(f)((acc, x) => App(acc, Seq(x)))

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
@@ -10,7 +10,7 @@ sealed abstract class HOAS extends Product with Serializable {
   def normalise: HOAS = {
     // println(s"NORMALISING ${this.reify}")
     val normalised = this match {
-      case Abs(_, f) => Abs(x => f(x).normalise)
+      case Abs(n, f) => Abs(n, x => f(x).normalise)
       case App(f, x) => f.whnf match {
         case Abs(_, g) => g(x).normalise
         case g      => App(g.normalise, x.map(_.normalise))
@@ -36,6 +36,7 @@ sealed abstract class HOAS extends Product with Serializable {
   def reify: Function = {
     val reified = this match {
       case Abs(n, f) => {
+        println(s"REIFYING ABS $n $f")
         val params = (1 to n).map(_ => Function.Var(Some("hoas"))).toList
         Function.Lam(params, f(params.map(x => HOAS.Var(x.name, None))).reify)
       }

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
@@ -1,0 +1,66 @@
+package parsley.garnish.model
+
+import scala.meta._
+import scalafix.v1._
+
+sealed abstract class HOAS extends Product with Serializable {
+  import HOAS._
+
+  def normalise: HOAS = this match {
+    case Abs(f) => Abs(x => f(x).normalise)
+    case App(f, x) => f.whnf match {
+      case Abs(g) => g(x).normalise
+      case g      => App(g.normalise, x.map(_.normalise))
+      // case g      => App(g.normalise, x.normalise.asInstanceOf[Tuple]) // TODO: ew, but this should be guaranteed
+    }
+    // case Tuple(xs) => Tuple(xs.map(_.normalise))
+    case Opaque(t, env) => Opaque(t, env.map { case (k, v) => k -> v.normalise })
+    case _ => this
+  }
+
+  private def whnf: HOAS = this match {
+    case App(f, x) => f.whnf match {
+      case Abs(g) => g(x).whnf
+      case g      => App(g, x)
+    }
+    case Opaque(t, env) => Opaque(t, env.map { case (k, v) => k -> v.whnf })
+    case _ => this
+  }
+
+  def reify: Term = this match {
+    // case Abs(f) => Function.Lam(Seq.empty, f(Var(Term.Name("x"))).reify)
+    // case App(f, x) => Function.App(f.reify, x.reify)
+    // case Opaque(t, env) => Function.Opaque(t, env.map { case (k, v) => k -> v.reify })
+    // case Var(name) => Function.Var(name)
+    case _ => ???
+  }
+}
+
+object HOAS {
+  case class Abs(f: Seq[HOAS] => HOAS) extends HOAS
+
+  case class App(f: HOAS, xs: Seq[HOAS]) extends HOAS
+  object App {
+    def apply(f: Seq[HOAS], xs: Seq[HOAS]): App = {
+      assert(f.size == 1) // TODO: ew
+      App(f.head, xs)
+    }
+  }
+
+  // TODO: this is a specialisation of Opaque (for 'unknowns'), I guess, so is this required?
+  case class Var(name: Term.Name) extends HOAS
+
+  // case class Tuple(xs: Seq[HOAS]) extends HOAS
+
+  case class Opaque(t: Term, env: Map[String, HOAS] = Map.empty) extends HOAS
+
+  // def appC(f: HOAS, xs: HOAS*): HOAS = xs.foldLeft(f)(App(_, _))
+  def appC(f: HOAS, xs: HOAS*): HOAS = xs.foldLeft(f)((acc, x) => App(acc, Seq(x)))
+
+  /* flip : (A => B => C) => B => A => C */
+  def flip: HOAS = {
+    // \f -> \x -> \y -> f y x
+    // Abs(f => Abs(x => Abs(y => appC(f, y, x))))
+    Abs(f => Abs(x => Abs(y => App(App(f, y), x))))
+  }
+}

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/HOAS.scala
@@ -8,7 +8,7 @@ sealed abstract class HOAS extends Product with Serializable {
   import HOAS._
 
   def normalise: HOAS = {
-    println(s"NORMALISING ${this.reify}")
+    // println(s"NORMALISING ${this.reify}")
     val normalised = this match {
       case Abs(_, f) => Abs(x => f(x).normalise)
       case App(f, x) => f.whnf match {
@@ -20,7 +20,7 @@ sealed abstract class HOAS extends Product with Serializable {
       case Opaque(t, env) => Opaque(t, env.map { case (k, v) => k -> v.normalise })
       case _ => this
     }
-    println(s"\tNORMALISED ${this.reify} to ${normalised.reify}")
+    // println(s"\tNORMALISED ${this.reify} to ${normalised.reify}")
     normalised
   }
 
@@ -37,13 +37,14 @@ sealed abstract class HOAS extends Product with Serializable {
     val reified = this match {
       case Abs(n, f) => {
         val params = (1 to n).map(_ => Function.Var(Some("hoas"))).toList
-        Function.Lam(params, f(params.map(x => HOAS.Opaque(x.term))).reify)
+        Function.Lam(params, f(params.map(x => HOAS.Var(x.name, None))).reify)
       }
       case App(f, xs) => {
-        println(s"REIFYING APP $f $xs")
+        // println(s"REIFYING APP $f $xs")
         Function.App(f.reify, xs.map(_.reify): _*)
       }
       case Opaque(t, env) => Function.Opaque(t, env.map { case (v, f) => v -> f.reify })
+      case Var(name, displayType) => Function.Var(name, displayType)
     }
     // println(s"REIFIED $this to $reified")
     reified
@@ -65,7 +66,7 @@ object HOAS {
   }
 
   // TODO: this is a specialisation of Opaque (for 'unknowns'), I guess, so is this required?
-  // case class Var(name: Term.Name) extends HOAS
+  case class Var(name: VarName, displayType: Option[Type]) extends HOAS
 
   // case class Tuple(xs: Seq[HOAS]) extends HOAS
 

--- a/parsley-garnish/tests/src/test/scala/parsley/garnish/analysis/MethodParametersAnalyzerTest.scala
+++ b/parsley-garnish/tests/src/test/scala/parsley/garnish/analysis/MethodParametersAnalyzerTest.scala
@@ -12,8 +12,6 @@ import scala.reflect.ClassTag
 
 import MethodParametersAnalyzer._
 
-import parsley.garnish.model.Function._
-
 class MethodParametersAnalyzerTest extends AnyFlatSpec with Matchers {
   implicit def termEq[T <: Term : ClassTag] = new Equality[T] {
     def areEqual(a: T, b: Any): Boolean = b match {


### PR DESCRIPTION
Migrate away from the previous normalisation by substitution approach, which relies on Barendregt's convention being upheld at all times. This is hard to do and the previous implementation could contain some very subtle bugs.