### PR TITLE
Improve output of factor left recursion rule

### DIFF
--- a/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/SimplifyComplexParsersTest.scala
@@ -7,9 +7,27 @@ import parsley.Parsley, parsley.Parsley._
 import parsley.character._
 import parsley.combinator._
 import parsley.syntax.character._
+import parsley.generic._
 
 object SimplifyComplexParsersTest {
     def add[A](a: A, b: String): String = a.toString + b
+
+    sealed trait Expr
+    case class Add(x: Expr, y: Expr) extends Expr
+    case class Sub(x: Expr, y: Expr) extends Expr
+    case class Mul(x: Expr, y: Expr) extends Expr
+    case class Neg(x: Expr) extends Expr
+    case class Num(x: Int) extends Expr
+
+    object Add extends ParserBridge2[Expr, Expr, Add]
+    object Sub extends ParserBridge2[Expr, Expr, Sub]
+    object Mul extends ParserBridge2[Expr, Expr, Mul]
+    object Neg extends ParserBridge1[Expr, Neg]
+    object Num extends ParserBridge1[Int, Num]
+
+    val HELLO = (char('*') ~> pure((x: Expr) => (y: Expr) => Mul(x, y))) <*> negate
+    lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
+    lazy val atom: Parsley[Expr] = Num(item.map(_.asDigit))
 
     val altRightNeutral = "anise" <|> empty
     val altLeftNeutral = empty | "coriander"

--- a/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
@@ -28,7 +28,6 @@ object ExprTest {
   lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
   lazy val atom: Parsley[Expr] = (char('(') ~> expr <~ char(')')) | Num(number)
 
-  def add(a: String)(b: String) = a + b
-  lazy val ruleA = ruleB.map(add) <*> string("a") | string("a")
-  lazy val ruleB: Parsley[String] = ruleA.map(add) <*> string("b") | string("b")
+  lazy val ruleA = ruleB.map(a => b => a + b) <*> string("a") | string("a")
+  lazy val ruleB: Parsley[String] = ruleA.map(a => b => a + b) <*> string("b") | string("b")
 }

--- a/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
@@ -1,0 +1,34 @@
+/*
+rule = FactorLeftRecursion
+ */
+package test.leftrec
+
+import parsley.Parsley
+import parsley.character._
+import parsley.generic._
+
+object ExprTest {
+  sealed trait Expr
+  case class Add(x: Expr, y: Expr) extends Expr
+  case class Sub(x: Expr, y: Expr) extends Expr
+  case class Mul(x: Expr, y: Expr) extends Expr
+  case class Neg(x: Expr) extends Expr
+  case class Num(x: Int) extends Expr
+
+  object Add extends ParserBridge2[Expr, Expr, Add]
+  object Sub extends ParserBridge2[Expr, Expr, Sub]
+  object Mul extends ParserBridge2[Expr, Expr, Mul]
+  object Neg extends ParserBridge1[Expr, Neg]
+  object Num extends ParserBridge1[Int, Num]
+
+  val number = digit.foldLeft1(0)(((n, d) => n * 10 + d.asDigit))
+
+  lazy val expr: Parsley[Expr] = Add(expr, char('+') ~> term) | Sub(expr, char('-') ~> term) | term
+  lazy val term: Parsley[Expr] = Mul(term, char('*') ~> negate) | negate
+  lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
+  lazy val atom: Parsley[Expr] = (char('(') ~> expr <~ char(')')) | Num(number)
+
+  def add(a: String)(b: String) = a + b
+  lazy val ruleA = ruleB.map(add) <*> string("a") | string("a")
+  lazy val ruleB: Parsley[String] = ruleA.map(add) <*> string("b") | string("b")
+}

--- a/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/input/src/main/scala/test/leftrec/ExprTest.scala
@@ -6,6 +6,7 @@ package test.leftrec
 import parsley.Parsley
 import parsley.character._
 import parsley.generic._
+import parsley.syntax.zipped._
 
 object ExprTest {
   sealed trait Expr
@@ -22,7 +23,6 @@ object ExprTest {
   object Num extends ParserBridge1[Int, Num]
 
   val number = digit.foldLeft1(0)(((n, d) => n * 10 + d.asDigit))
-
   lazy val expr: Parsley[Expr] = Add(expr, char('+') ~> term) | Sub(expr, char('-') ~> term) | term
   lazy val term: Parsley[Expr] = Mul(term, char('*') ~> negate) | negate
   lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
@@ -30,4 +30,6 @@ object ExprTest {
 
   lazy val ruleA = ruleB.map(a => b => a + b) <*> string("a") | string("a")
   lazy val ruleB: Parsley[String] = ruleA.map(a => b => a + b) <*> string("b") | string("b")
+
+  lazy val p: Parsley[String] = (p, string("a")).zipped(_ + _) | string("b")
 }

--- a/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
@@ -22,16 +22,16 @@ object ExprTest {
   object Num extends ParserBridge1[Int, Num]
 
   val number = digit.foldLeft1(0)(((n, d) => n * 10 + d.asDigit))
-
   // TODO: fix compilation issues with expr, term
   lazy val expr: Parsley[Expr] = chain.postfix[Expr](term)((char('+') ~> term).map(hoas611 => hoas612 => Add.curried(hoas612)(hoas611)) | (char('-') ~> term).map(hoas613 => hoas614 => Sub.curried(hoas614)(hoas613)))
   lazy val term: Parsley[Expr] = chain.postfix[Expr](negate)((char('*') ~> negate).map(hoas841 => hoas842 => Mul.curried(hoas842)(hoas841)))
   lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
   lazy val atom: Parsley[Expr] = (char('(') ~> expr <~ char(')')) | Num(number)
 
-  def add(a: String)(b: String) = a + b
   // lazy val ruleA = chain.postfix[String](string("b").map(hoas677 => hoas678 => hoas677 + hoas678) <*> string("a") | string("a"))(string("b").map(hoas679 => hoas680 => hoas681 => hoas681 + hoas679 + hoas680) <*> string("a"))
   // TODO: if I could rewrite using zipped syntax to have better type inference, that would be great
   lazy val ruleA = chain.postfix[String](string("b").map(hoas677 => hoas678 => hoas677 + hoas678) <*> string("a") | string("a"))((string("b"), string("a")).zipped((hoas679, hoas680) => hoas681 => hoas681 + hoas679 + hoas680))
-  lazy val ruleB: Parsley[String] = ruleA.map(add) <*> string("b") | string("b")
+  lazy val ruleB: Parsley[String] = ruleA.map(a => b => a + b) <*> string("b") | string("b")
+
+  lazy val p: Parsley[String] = chain.postfix[String](string("b"))(string("a").map(hoas21 => hoas22 => hoas22 + hoas21))
 }

--- a/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
@@ -1,0 +1,32 @@
+package test.leftrec
+
+import parsley.Parsley
+import parsley.character._
+import parsley.generic._
+import parsley.expr.chain
+
+object ExprTest {
+  sealed trait Expr
+  case class Add(x: Expr, y: Expr) extends Expr
+  case class Sub(x: Expr, y: Expr) extends Expr
+  case class Mul(x: Expr, y: Expr) extends Expr
+  case class Neg(x: Expr) extends Expr
+  case class Num(x: Int) extends Expr
+
+  object Add extends ParserBridge2[Expr, Expr, Add]
+  object Sub extends ParserBridge2[Expr, Expr, Sub]
+  object Mul extends ParserBridge2[Expr, Expr, Mul]
+  object Neg extends ParserBridge1[Expr, Neg]
+  object Num extends ParserBridge1[Int, Num]
+
+  val number = digit.foldLeft1(0)(((n, d) => n * 10 + d.asDigit))
+
+  lazy val expr: Parsley[Expr] = chain.postfix[Expr](term.map(Mul.apply.curried) <*> char('*') ~> negate | ((string("negate") ~> negate).map(Neg.apply) | (char('(') ~> expr <~ char(')') | digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit).map(Num.apply))))((char('+') ~> term).map(hoas535 => (hoas536: Expr) => Add.apply.curried(hoas536)(hoas535)) | (char('-') ~> term).map(hoas537 => (hoas538: Expr) => Sub.apply.curried(hoas538)(hoas537)))
+  lazy val term: Parsley[Expr] = chain.postfix[Expr]((string("negate") ~> negate).map(Neg.apply) | (char('(') ~> expr <~ char(')') | digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit).map(Num.apply)))((char('*') ~> negate).map(hoas680 => hoas681 => Mul.apply.curried(hoas681)(hoas680)))
+  lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
+  lazy val atom: Parsley[Expr] = (char('(') ~> expr <~ char(')')) | Num(number)
+
+  def add(a: String)(b: String) = a + b
+  lazy val ruleA = ruleB.map(add) <*> string("a") | string("a")
+  lazy val ruleB: Parsley[String] = ruleA.map(add) <*> string("b") | string("b")
+}

--- a/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
+++ b/parsley-garnish/output/src/main/scala/test/leftrec/ExprTest.scala
@@ -4,6 +4,8 @@ import parsley.Parsley
 import parsley.character._
 import parsley.generic._
 import parsley.expr.chain
+import parsley.lift._
+import parsley.syntax.zipped._
 
 object ExprTest {
   sealed trait Expr
@@ -21,12 +23,15 @@ object ExprTest {
 
   val number = digit.foldLeft1(0)(((n, d) => n * 10 + d.asDigit))
 
-  lazy val expr: Parsley[Expr] = chain.postfix[Expr](term.map(Mul.apply.curried) <*> char('*') ~> negate | ((string("negate") ~> negate).map(Neg.apply) | (char('(') ~> expr <~ char(')') | digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit).map(Num.apply))))((char('+') ~> term).map(hoas535 => (hoas536: Expr) => Add.apply.curried(hoas536)(hoas535)) | (char('-') ~> term).map(hoas537 => (hoas538: Expr) => Sub.apply.curried(hoas538)(hoas537)))
-  lazy val term: Parsley[Expr] = chain.postfix[Expr]((string("negate") ~> negate).map(Neg.apply) | (char('(') ~> expr <~ char(')') | digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit).map(Num.apply)))((char('*') ~> negate).map(hoas680 => hoas681 => Mul.apply.curried(hoas681)(hoas680)))
+  // TODO: fix compilation issues with expr, term
+  lazy val expr: Parsley[Expr] = chain.postfix[Expr](term)((char('+') ~> term).map(hoas611 => hoas612 => Add.curried(hoas612)(hoas611)) | (char('-') ~> term).map(hoas613 => hoas614 => Sub.curried(hoas614)(hoas613)))
+  lazy val term: Parsley[Expr] = chain.postfix[Expr](negate)((char('*') ~> negate).map(hoas841 => hoas842 => Mul.curried(hoas842)(hoas841)))
   lazy val negate: Parsley[Expr] = Neg(string("negate") ~> negate) | atom
   lazy val atom: Parsley[Expr] = (char('(') ~> expr <~ char(')')) | Num(number)
 
   def add(a: String)(b: String) = a + b
-  lazy val ruleA = ruleB.map(add) <*> string("a") | string("a")
+  // lazy val ruleA = chain.postfix[String](string("b").map(hoas677 => hoas678 => hoas677 + hoas678) <*> string("a") | string("a"))(string("b").map(hoas679 => hoas680 => hoas681 => hoas681 + hoas679 + hoas680) <*> string("a"))
+  // TODO: if I could rewrite using zipped syntax to have better type inference, that would be great
+  lazy val ruleA = chain.postfix[String](string("b").map(hoas677 => hoas678 => hoas677 + hoas678) <*> string("a") | string("a"))((string("b"), string("a")).zipped((hoas679, hoas680) => hoas681 => hoas681 + hoas679 + hoas680))
   lazy val ruleB: Parsley[String] = ruleA.map(add) <*> string("b") | string("b")
 }

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/implicits.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/implicits.scala
@@ -39,6 +39,8 @@ object implicits {
         Empty.fromTerm,
         Choice.fromTerm,
         Ap.fromTerm,
+        Then.fromTerm,
+        ThenDiscard.fromTerm,
         FMap.fromTerm,
         Many.fromTerm,
         SomeP.fromTerm,

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Parser.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Parser.scala
@@ -184,35 +184,19 @@ object Parser {
       val UnfoldedParser(pe, pn, pl) = p.unfold
       val UnfoldedParser(qe, qn, ql) = q.unfold
 
-      println(s"AP $this")
-
       val empty =
         if (pe.isDefined && qe.isDefined) Some(App(pe.get, qe.get)) // pure f <*> pure x = pure (f x)
         else None
-      
-      println(s"\tEMPTY = $empty; pe = $pe, qe = $qe")
 
       val lefts = {
         val llr = pl.map(flip) <*> q
-        val rlr = pe match {
-          case None => Empty
-          case Some(f) => ql.map(composeH(f))
-        }
-
-        println(s"\tLEFTS = ${(llr <|> rlr).simplify}, llr = $llr, rlr = $rlr")
-
+        val rlr = pe.map(f => ql.map(composeH(f))).getOrElse(Empty)
         llr <|> rlr
       }
 
       val nonLefts = {
         val lnl = pn <*> q
-        val rnl = pe match {
-          case None => Empty
-          case Some(f) => qn.map(f)
-        }
-
-        println(s"\tNON-LEFTS = ${(lnl <|> rnl).simplify}, lnl = $lnl, rnl = $rnl")
-
+        val rnl = pe.map(f => qn.map(f)).getOrElse(Empty)
         rnl <|> lnl
       }
 

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Parser.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/model/Parser.scala
@@ -88,7 +88,7 @@ sealed abstract class Parser extends Product with Serializable {
     this.transform(pf0)
   }
 
-  override def toString: String = term.syntax
+  // override def toString: String = term.syntax
 }
 
 object Parser {
@@ -386,7 +386,9 @@ object Parser {
   }
   object LiftImplicit {
     val matcher = SymbolMatcher.normalized(
-      (0 to 22).map(i => s"parsley.syntax.lift.liftSyntax$i"): _*
+      (0 to 22).map(i =>
+        Seq(s"parsley.syntax.Lift$i#lift", s"parsley.syntax.lift.liftSyntax$i")
+      ).flatten: _*
     )
 
     def fromTerm(implicit doc: SemanticDocument): PartialFunction[Term, LiftImplicit] = {
@@ -421,7 +423,9 @@ object Parser {
   }
   object Zipped {
     val matcher = SymbolMatcher.normalized(
-      (2 to 22).map(i => s"parsley.syntax.zipped.zippedSyntax$i"): _*
+      (2 to 22).map(i =>
+        Seq(s"parsley.syntax.Zipped$i#zipped", s"parsley.syntax.zipped.zippedSyntax$i")
+      ).flatten: _*
     )
 
     def fromTerm(implicit doc: SemanticDocument): PartialFunction[Term, Zipped] = {

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/SimplifyComplexParsers.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/SimplifyComplexParsers.scala
@@ -8,7 +8,7 @@ import parsley.garnish.analysis.ParserTransformer.{getAllParserDefns, ParserDefi
 class SimplifyComplexParsers extends SemanticRule("SimplifyComplexParsers") {
   override def fix(implicit doc: SemanticDocument): Patch = {
     getAllParserDefns.map { case ParserDefinition(_, parser, _, originalTree) =>
-      val simplifiedParser = parser.normalise
+      val simplifiedParser = parser.simplify
       if (simplifiedParser != parser) {
         val simplifiedParserTerm = simplifiedParser.term.syntax
         Patch.replaceTree(originalTree, simplifiedParserTerm)

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
@@ -21,6 +21,7 @@ object Transformation {
       }
     }
 
+    // TODO: make patches atomic?
     nonTerminals.values.map {
       case ParserDefinition(_, transformed, _, originalTree) =>
           Patch.replaceTree(originalTree, transformed.term.syntax)
@@ -35,14 +36,15 @@ object Transformation {
       case Some(t) => Pure(t)
     }
 
-    leftRec.normalise match {
+    leftRec.simplify match {
       case Empty => None
       // case Pure(_) => None  // TODO: special case: report infinite loop which couldn't be left factored -- should this be looking for any parser which can parse empty?
       // TODO: import postfix if not in scope
       // TODO: report can't left factor if there are impure parsers
       case leftRec =>
         println(s">>> ${Postfix(tpe, nonLeftRec <|> empties, leftRec)}")
-        Some(Postfix(tpe, nonLeftRec <|> empties, leftRec).normalise)
+        println(s">>> POSTFIX: empties = ${empties.simplify}, nonLeftRec = ${nonLeftRec.simplify}, leftRec = ${leftRec.simplify}")
+        Some(Postfix(tpe, nonLeftRec <|> empties, leftRec).simplify)
     }
   }
 

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
@@ -15,7 +15,6 @@ object Transformation {
 
     for (sym <- nonTerminals.keys) {
       val unfolded = unfold(nonTerminals.toMap, sym)
-      println(s">>> UNFOLDED: $sym -> $unfolded")
       val transformedParser = transform(unfolded, nonTerminals(sym).tpe)
       if (transformedParser.isDefined) {
         nonTerminals(sym) = nonTerminals(sym).copy(parser = transformedParser.get)
@@ -43,8 +42,8 @@ object Transformation {
       // TODO: import postfix if not in scope
       // TODO: report can't left factor if there are impure parsers
       case leftRec =>
-        println(s">>> ${Postfix(tpe, nonLeftRec <|> empties, leftRec)}")
-        println(s">>> POSTFIX: empties = ${empties.simplify}, nonLeftRec = ${nonLeftRec.simplify}, leftRec = ${leftRec.simplify}")
+        // println(s">>> ${Postfix(tpe, nonLeftRec <|> empties, leftRec)}")
+        // println(s">>> POSTFIX: empties = ${empties.simplify}, nonLeftRec = ${nonLeftRec.simplify}, leftRec = ${leftRec.simplify}")
         Some(Postfix(tpe, nonLeftRec <|> empties, leftRec).simplify)
     }
   }

--- a/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
+++ b/parsley-garnish/rules/src/main/scala/parsley/garnish/rules/leftrec/Transformation.scala
@@ -15,6 +15,7 @@ object Transformation {
 
     for (sym <- nonTerminals.keys) {
       val unfolded = unfold(nonTerminals.toMap, sym)
+      println(s">>> UNFOLDED: $sym -> $unfolded")
       val transformedParser = transform(unfolded, nonTerminals(sym).tpe)
       if (transformedParser.isDefined) {
         nonTerminals(sym) = nonTerminals(sym).copy(parser = transformedParser.get)


### PR DESCRIPTION
Recursively inline the result of factored non-terminals only if they are actually left-recursive.
This allows us to handle direct recursion in a very readable way, and also indirect recursion in the case that we do need to inline a reference to another non-terminal.